### PR TITLE
Set disableStickyPositioning system property for nested scrollers

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/controller/JenkinsController.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/controller/JenkinsController.java
@@ -105,7 +105,9 @@ public abstract class JenkinsController implements IJenkinsController, AutoClean
         }
         try {
             URL url = getUrl();
-            // Inject the cookie to disable sticky elements.
+            // Inject the cookie to disable sticky elements / nested scrollers.
+            // Prefer also setting -Dhudson.Functions.disableStickyPositioning=true on the
+            // Jenkins-under-test JVM (see WinstoneController) — that does not depend on the browser.
             Cookie c = new Cookie.Builder("disableStickyPositioning", "true")
                     .isSecure("https".equalsIgnoreCase(url.getProtocol()))
                     .sameSite("Lax")
@@ -118,6 +120,8 @@ public abstract class JenkinsController implements IJenkinsController, AutoClean
                 // but this part needs to ensure it runs against one controller at once
                 d.navigate().to(url);
                 d.manage().addCookie(c);
+                // Reload so the first page is rendered with data-disable-sticky="true".
+                d.navigate().refresh();
             }
         } catch (Exception e) {
             LOGGER.log(

--- a/src/main/java/org/jenkinsci/test/acceptance/controller/WinstoneController.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/controller/WinstoneController.java
@@ -78,7 +78,12 @@ public class WinstoneController extends LocalController {
         CommandBuilder cb = new CommandBuilder(java);
         cb.addAll(JENKINS_JAVA_OPTS);
         cb.addAll(JAVA_OPTS);
-        cb.add("-Duser.language=en", "-Djenkins.formelementpath.FormElementPathPageDecorator.enabled=true");
+        cb.add(
+                "-Duser.language=en",
+                "-Djenkins.formelementpath.FormElementPathPageDecorator.enabled=true",
+                // Flatten nested page scrollers / sticky UI so Selenium can scrollIntoView.
+                // Survives even if the disableStickyPositioning cookie fails to inject.
+                "-Dhudson.Functions.disableStickyPositioning=true");
         portFile = File.createTempFile("jenkins-port", ".txt");
         portFile.deleteOnExit();
         cb.add("-Dwinstone.portFileName=" + portFile.getAbsolutePath());

--- a/src/main/java/org/jenkinsci/test/acceptance/controller/WinstoneDockerController.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/controller/WinstoneDockerController.java
@@ -67,6 +67,7 @@ public class WinstoneDockerController extends LocalController {
             cmds.add("java");
             cmds.add("-DJENKINS_HOME=/work");
             cmds.add("-Djenkins.formelementpath.FormElementPathPageDecorator.enabled=true");
+            cmds.add("-Dhudson.Functions.disableStickyPositioning=true");
             cmds.add("-jar", "/war/" + war.getName());
             cmds.add("--controlPort=8081", "--httpPort=8080");
             return container.popen(cmds);

--- a/vars.cmd
+++ b/vars.cmd
@@ -3,7 +3,7 @@ set DISPLAY=:0
 set INTERACTIVE=false
 set BROWSER=remote-webdriver-firefox
 set REMOTE_WEBDRIVER_URL=http://127.0.0.1:4444/wd/hub
-set JENKINS_JAVA_OPTS=-Xmx1280m
+set JENKINS_JAVA_OPTS=-Xmx1280m -Dhudson.Functions.disableStickyPositioning=true
 
 @REM Jenkins binds to 0.0.0.0 (OMG) so we can use any network but the docker network.
 @REM but we may as well use the default network

--- a/vars.sh
+++ b/vars.sh
@@ -13,7 +13,7 @@ export DISPLAY=:0
 export INTERACTIVE=false
 export BROWSER=remote-webdriver-firefox
 export REMOTE_WEBDRIVER_URL=http://127.0.0.1:4444/wd/hub
-export JENKINS_JAVA_OPTS=-Xmx1280m
+export JENKINS_JAVA_OPTS="-Xmx1280m -Dhudson.Functions.disableStickyPositioning=true"
 if [ -z "${JENKINS_WAR}" ] && [ -f /usr/share/java/jenkins.war ]; then
 	export JENKINS_WAR=/usr/share/java/jenkins.war
 fi


### PR DESCRIPTION
## Summary
- Launch Jenkins-under-test with `-Dhudson.Functions.disableStickyPositioning=true` (Winstone + Winstone Docker + local vars)
- Reload after injecting the `disableStickyPositioning` cookie so the first page is rendered with `data-disable-sticky="true"`

## Why
https://github.com/jenkinsci/jenkins/pull/26863 introduces nested `overflow-y: auto` page panes. Selenium cannot scroll targets into view inside those panes. Cookie-only disabling is easy to miss under remote WebDriver; a JVM system property is reliable.

Requires the companion Jenkins change that honors the system property in `Functions.isStickyPositioningDisabled()`.

## Test plan
- [ ] Merge Jenkins companion into `individual-scrollers` and bump `jenkins.version` to the new incremental
- [ ] Re-run ATH PR CI and confirm scroll-into-view failures are gone